### PR TITLE
Added embedded env type for CSI camera in video handler

### DIFF
--- a/configs/config_default.yaml
+++ b/configs/config_default.yaml
@@ -23,7 +23,9 @@ VideoSource:
   HTTP_URL: http://172.21.144.1:8100
   # CSI camera sensor ID if VIDEO_SOURCE_TYPE is 'CSI_CAMERA'
   CSI_SENSOR_ID: 0  # Typically 0 for the first camera
-
+  # hardware type for CSI Camera used by handler
+  EMBEDDED_ENVIRONMENT: rasspberry_pi  # Set to 'raspberry_pi' for Raspberry Pi, 'nvidia' for nvidia Jetson
+   
 # ==============================================================================
 # Camera Configuration
 # ==============================================================================


### PR DESCRIPTION
When using the CSI_CAMERA. By default, GStreamer pipeline is only defined for Nvidia boards. Raspberry Pi camera CSI have been added to the pipeline in video handler class and configuration file.